### PR TITLE
Inspect Defaults to YMD Formatting

### DIFF
--- a/c10_tools/inspect.py
+++ b/c10_tools/inspect.py
@@ -72,7 +72,7 @@ class Inspect:
 
                     # Julian day or month/year
                     fmt = '%j %H:%M:%S.%f'
-                    if self.date_format:
+                    if getattr(self, "date_format", True):
                         fmt = '%Y-%m-%d %H:%M:%S.%f'
 
                     val = packet.get_time().strftime(fmt)

--- a/tests/test_inspect.py
+++ b/tests/test_inspect.py
@@ -67,3 +67,19 @@ def test_error_ascii(args):
 |      14 |   64 |      196 |  15,636 | 343 16:47:12.254729         | Yes   |          24,182 |
 |      18 |   64 |      195 |  15,636 | 343 16:47:12.255114         | Yes   |          39,818 |'''.format(
     colored('Packet length incorrect at 6,716', 'red'))
+
+
+def test_inspect_filtering(args):
+    type_counts = [
+        (1, 2),
+        (17, 2),
+        (25, 13),
+        (48, 7),
+        (56, 19),
+        (64, 58),
+    ]
+    args['<file>'] = [pytest.SAMPLE]
+    for typ, expected in type_counts:
+        args['--type'] = str(typ)
+        result = list(main(args))
+        assert len(result) == expected


### PR DESCRIPTION
Inspect defaults to YMD date formatting (avoids an error when accessing non-existent attribute under certain conditions).

Adds additional inspect test, `test_inspect_filtering`, that enables filtering for all of the types in the `1.c10` example and verifies the expected number of output lines for each type.

Resolves #19